### PR TITLE
Fix up lsl->slua rotation type conversion

### DIFF
--- a/src/utils/slua.ts
+++ b/src/utils/slua.ts
@@ -6,8 +6,8 @@ export function toLuauType(lslType: string): string {
     'string': 'string',
     'key': 'string',
     'vector': 'vector',
-    'rotation': 'vector',
-    'quaternion': 'vector',
+    'rotation': 'quaternion',
+    'quaternion': 'quaternion',
     'list': '{any}',
     'void': '()'
   };


### PR DESCRIPTION
Provide the right type alias when converting lsl_definition.yaml rotation types to slua.