### PR TITLE
Provide a better SLua event signature

### DIFF
--- a/src/components/SLuaEvent.astro
+++ b/src/components/SLuaEvent.astro
@@ -25,9 +25,11 @@ if (!eventDef) {
 
 const args = Object.values(eventDef.arguments);
 
-// Build event signature with Luau typing
-const params = args.map((arg: Argument) => `${arg.name}: ${toLuauType(arg.type)}`).join(', ');
-const signature = `function ${name}(${params})`;
+// Build event signature with Luau typing for LLEvents:on format
+const params = args
+  .map((arg: Argument) => `${arg.name}: ${toLuauType(arg.type)}`)
+  .join(', ');
+const signature = `LLEvents:on("${name}", function(${params})\n  -- ...\nend)`;
 
 // Map arguments to Luau types for display
 const luauArgs: Record<string, Argument> = {};

--- a/src/utils/lsl-definitions.ts
+++ b/src/utils/lsl-definitions.ts
@@ -133,6 +133,7 @@ function convertArguments(argRecords: Record<string, Argument>[]): Record<string
     const args: Record<string, Argument> = {};
     for (const record of argRecords) {
         for (const key in record) {
+            record[key].name = key;
             args[key] = record[key];
         }
     }


### PR DESCRIPTION
Provide a more accurate/meaningful example of SLua event handlers in the SLua event reference pages.

Previous:
```luau
function http_response(undefined: string, undefined: number, undefined: {any}, undefined: string)
```

New:
```luau
LLEvents:on("http_response", function(HTTPRequestID: string, Status: number, Metadata: {any}, Body: string)
  -- ...
end)
```