### PR TITLE
Tweaked accordion summary styles

### DIFF
--- a/src/styles/function-reference.css
+++ b/src/styles/function-reference.css
@@ -101,13 +101,14 @@
   border: 1px solid var(--sl-color-hairline);
   border-radius: 0.5rem;
   padding: 0;
+  overflow: hidden;
 }
 
 .function-metadata-details summary {
   cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
-  padding: 0.75rem;
+  padding: 0.75rem 0.75rem 0.75rem 1rem;
   user-select: none;
   list-style: none;
   display: flex;
@@ -143,13 +144,14 @@
   border: 1px solid var(--sl-color-hairline);
   border-radius: 0.5rem;
   padding: 0;
+  overflow: hidden;
 }
 
 .function-parameters-details summary {
   cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
-  padding: 0.75rem;
+  padding: 0.75rem 0.75rem 0.75rem 1rem;
   user-select: none;
   list-style: none;
   display: flex;


### PR DESCRIPTION
Fixes overflow on accordion hover background styles, plus a slight tweak to left-padding

**Before**

![jvamnIe5](https://github.com/user-attachments/assets/e192750f-9513-4852-9c83-20dc6c98994d)

**After**

![rQU61Z2n](https://github.com/user-attachments/assets/c495c06c-3a25-4a8a-901f-73e01bad41f2)