### PR TITLE
Update install instructions to use 'run' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Built with [Astro](https://astro.build) and [Starlight](https://starlight.astro.
 pnpm install
 
 # Start dev server at http://localhost:4321
-pnpm dev
+pnpm run dev
 
 # Build for production
-pnpm build
+pnpm run build
 ```
 
 ## Contributing


### PR DESCRIPTION
`pnpm dev`/`pnpm build` are not real commands or might have unexpected behaviours as the intention is instead to run the package.json scripts, not functionality specific to pnpm