### PR TITLE
Enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    assignees:
+      - mcgroarty
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    assignees:
+      - mcgroarty


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automatic dependency updates.

## What this enables

- **npm ecosystem** — weekly updates for `package.json` dependencies (handles the pnpm lockfile natively).
  - Astro / `@astrojs/*` packages grouped into a single PR to reduce noise.
  - All dev dependencies grouped into a single PR.
- **github-actions ecosystem** — weekly updates for action versions referenced in `.github/workflows/ci.yml` and `deploy.yml`.

## Settings

- PR limit: 10 (npm)
- Assignee: @mcgroarty on both ecosystems

Once merged, Dependabot picks up the config automatically — no repo setting changes required.
