### PR TITLE
Address Code Scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-lint:
     name: Build and Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: '24'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '24'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 

--- a/scripts/fetch-definitions.js
+++ b/scripts/fetch-definitions.js
@@ -24,7 +24,8 @@ export async function fetchDefinitions(url = DEFAULT_URL) {
     // Ensure the directory exists
     await mkdir(dirname(OUTPUT_PATH), { recursive: true });
 
-    // Write the file
+    // OUTPUT_PATH is hardcoded via import.meta.url; HTTP response cannot influence the write location.
+    // lgtm[js/http-to-file-access]
     await writeFile(OUTPUT_PATH, content, 'utf8');
 
     console.log(`Successfully saved LSL definitions to: ${OUTPUT_PATH}`);


### PR DESCRIPTION
Addresses all 4 open Code Scanning alerts.

## Changes

### Alert #1 — `actions/missing-workflow-permissions` (`ci.yml`)
Added an explicit least-privilege permissions block at the workflow level:
```yaml
permissions:
  contents: read
```
The CI workflow only checks out code, builds, and uploads an artifact — no repo write access needed. `deploy.yml` already had a correct permissions block, so it wasn't flagged.

### Alerts #2 & #3 — `actions/unpinned-tag` (`ci.yml`, `deploy.yml`)
Pinned `pnpm/action-setup@v4` to its commit SHA `b906affcce14559ad1aafd4ab0e942779e9f58b1` in both workflows, with a trailing `# v4` comment so Dependabot continues to track the v4 line and can update both the SHA and comment in lockstep.

### Alert #4 — `js/http-to-file-access` (`scripts/fetch-definitions.js`)
Added an `lgtm[js/http-to-file-access]` suppression comment with justification. The rule's underlying concern (HTTP response controlling the write path) does not apply here — `OUTPUT_PATH` is hardcoded via `import.meta.url`, and the HTTP response only controls file *contents*, never file *location*. The default URL is a hardcoded `secondlife/lsl-definitions` raw URL, and the content is parsed downstream as YAML data, not executed.

## Notes
- `pnpm/action-setup` is currently at v6.0.8; Dependabot will likely propose a major bump shortly after #28 merges. Handling that as a separate PR is recommended since v5/v6 changed how the pnpm version is resolved.
- Does not depend on PR #28, but will compose well with it.
