### PR TITLE
Remove stale LGTM suppression pragma

### DIFF
--- a/scripts/fetch-definitions.js
+++ b/scripts/fetch-definitions.js
@@ -25,7 +25,6 @@ export async function fetchDefinitions(url = DEFAULT_URL) {
     await mkdir(dirname(OUTPUT_PATH), { recursive: true });
 
     // OUTPUT_PATH is hardcoded via import.meta.url; HTTP response cannot influence the write location.
-    // lgtm[js/http-to-file-access]
     await writeFile(OUTPUT_PATH, content, 'utf8');
 
     console.log(`Successfully saved LSL definitions to: ${OUTPUT_PATH}`);


### PR DESCRIPTION
Removes a `// lgtm[js/http-to-file-access]` comment in [scripts/fetch-definitions.js](scripts/fetch-definitions.js) that has been a no-op since LGTM.com was retired in 2022. Modern CodeQL does not honor inline LGTM pragmas, so it was creating a false sense of suppression.

The explanatory comment above it is preserved.

The associated CodeQL alert will be dismissed as a false positive separately: `OUTPUT_PATH` is derived from `import.meta.url` at module load and cannot be influenced by the HTTP response, so there is no path-traversal/arbitrary-write risk.